### PR TITLE
Fix partial pattern matching in deserializer

### DIFF
--- a/test/Crypto/Macaroon/Serializer/Base64/Tests.hs
+++ b/test/Crypto/Macaroon/Serializer/Base64/Tests.hs
@@ -26,6 +26,7 @@ tests :: TestTree
 tests = testGroup "Crypto.Macaroon.Serializer.Base64" [ basic
                                                       , minted
                                                       , minted2
+                                                      , emptyString
                                                       -- , minted3
                                                       ]
 
@@ -87,3 +88,8 @@ mint2Trimmed = testCase "Serialization" $
 mint2Des = testCase "Deserialization" $
     Right m3 @=? (deserialize . serialize) m3
 
+emptyString :: TestTree
+emptyString = testGroup "Empty string" [ emptyStringDes ]
+
+emptyStringDes = testCase "Deserialization should fail gracefully" $
+    Left "Failed reading: missing macaroon header" @=? deserialize ""


### PR DESCRIPTION
This made parsing crash on empty strings for instance. (I've addded a test case for that precise issue)

I've replaced the let pattern matching with `case / of` constructs. Maybe there's a more idiomatic way of doing it, in that case (pun intended), please tell me so I can fix it.

Adrien, this PR is not on an internal project, but please chime in if you want :-)