### PR TITLE
Better verifier results

### DIFF
--- a/hmacaroons.cabal
+++ b/hmacaroons.cabal
@@ -57,6 +57,7 @@ library
                        Crypto.Macaroon.Verifier
   other-modules:       Crypto.Macaroon.Internal
                        Crypto.Macaroon.Verifier.Internal
+  ghc-options:    -fwarn-unused-imports
   build-depends:  base >=4 && < 5,
                   attoparsec >=0.12,
                   transformers >= 0.3,

--- a/hmacaroons.cabal
+++ b/hmacaroons.cabal
@@ -70,8 +70,7 @@ library
                   -- nonce,
                   -- cipher-aes >=0.2 && <0.3,
                   deepseq >= 1.1,
-                  hex >= 0.1,
-                  text >= 1.2
+                  hex >= 0.1
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -93,8 +92,7 @@ benchmark bench
                   either >=4.4,
                   hex >= 0.1,
                   deepseq >= 1.1,
-                  criterion >= 1.1,
-                  text >= 1.2
+                  criterion >= 1.1
 
 test-suite test
   default-language: Haskell2010
@@ -115,5 +113,4 @@ test-suite test
                   tasty-quickcheck >= 0.8,
                   QuickCheck >= 2.8,
                   deepseq >= 1.1,
-                  transformers >= 0.3,
-                  text >= 1.2
+                  transformers >= 0.3

--- a/hmacaroons.cabal
+++ b/hmacaroons.cabal
@@ -69,7 +69,8 @@ library
                   -- nonce,
                   -- cipher-aes >=0.2 && <0.3,
                   deepseq >= 1.1,
-                  hex >= 0.1
+                  hex >= 0.1,
+                  text >= 1.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -91,7 +92,8 @@ benchmark bench
                   either >=4.4,
                   hex >= 0.1,
                   deepseq >= 1.1,
-                  criterion >= 1.1
+                  criterion >= 1.1,
+                  text >= 1.2
 
 test-suite test
   default-language: Haskell2010
@@ -112,4 +114,5 @@ test-suite test
                   tasty-quickcheck >= 0.8,
                   QuickCheck >= 2.8,
                   deepseq >= 1.1,
-                  transformers >= 0.3
+                  transformers >= 0.3,
+                  text >= 1.2

--- a/src/Crypto/Macaroon/Internal.hs
+++ b/src/Crypto/Macaroon/Internal.hs
@@ -17,9 +17,8 @@ module Crypto.Macaroon.Internal where
 import           Control.DeepSeq
 import           Crypto.Hash
 import           Data.Byteable
-import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Base64 as B64
-import qualified Data.ByteString.Char8  as B8
+import qualified Data.ByteString       as BS
+import qualified Data.ByteString.Char8 as B8
 import           Data.Hex
 import           Data.List
 

--- a/src/Crypto/Macaroon/Serializer/Base64.hs
+++ b/src/Crypto/Macaroon/Serializer/Base64.hs
@@ -21,15 +21,12 @@ import           Control.Monad
 import           Crypto.Macaroon.Internal
 import           Data.Attoparsec.ByteString
 import qualified Data.Attoparsec.ByteString.Char8 as A8
-import           Data.Bits
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Base64.URL       as B64
 import qualified Data.ByteString.Char8            as B8
 import           Data.Char
 import           Data.Hex
-import           Data.Int
 import           Data.List
-import           Data.Maybe
 import           Data.Serialize
 import           Data.Word
 

--- a/src/Crypto/Macaroon/Verifier.hs
+++ b/src/Crypto/Macaroon/Verifier.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -48,13 +47,13 @@ import           Crypto.Macaroon.Verifier.Internal
 -- caveat, parsed it and invalidated it;
 -- * 'Verified' if the verifier has successfully verified the
 -- given caveat
-verify :: (Monad m) => Secret -> [Caveat -> m VerifierResult] -> Macaroon -> m (Either ValidationError Macaroon)
+verify :: (Monad m) => Secret -> [Caveat -> m (VerifierResult pe ve)] -> Macaroon -> m (Either (ValidationError pe ve) Macaroon)
 verify secret verifiers m = join <$> forM (verifySig secret m) (verifyCavs verifiers)
 
 -- | Synchronously verify a macaroon signature and caveats, given the
 -- corresponding Secret and verifiers.
 -- This is a variant of @verify@ working with synchronous verifiers.
-verifySync :: Secret -> [Caveat -> VerifierResult] -> Macaroon -> Either ValidationError Macaroon
+verifySync :: Secret -> [Caveat -> VerifierResult pe ve] -> Macaroon -> Either (ValidationError pe ve) Macaroon
 verifySync secret verifiers m =
     let verifiersIdent = fmap (fmap Identity) verifiers
     in runIdentity $ verify secret verifiersIdent m

--- a/src/Crypto/Macaroon/Verifier.hs
+++ b/src/Crypto/Macaroon/Verifier.hs
@@ -18,19 +18,20 @@ Portability : portable
 module Crypto.Macaroon.Verifier (
     verify
   , VerifierResult(..)
-  , ValidationError(ValidatorError, ParseError)
+  , VerifierError(..)
+  , ValidationError(..)
 ) where
 
 
 import           Control.Applicative
-import           Control.Monad hiding (forM)
+import           Control.Monad                     hiding (forM)
 import           Control.Monad.IO.Class
 import           Data.Attoparsec.ByteString
 import           Data.Attoparsec.ByteString.Char8
 import           Data.Bool
-import           Data.Traversable
-import qualified Data.ByteString                  as BS
+import qualified Data.ByteString                   as BS
 import           Data.Either.Combinators
+import           Data.Traversable
 
 import           Crypto.Macaroon.Internal
 import           Crypto.Macaroon.Verifier.Internal

--- a/src/Crypto/Macaroon/Verifier.hs
+++ b/src/Crypto/Macaroon/Verifier.hs
@@ -23,14 +23,8 @@ module Crypto.Macaroon.Verifier (
 ) where
 
 
-import           Control.Applicative
 import           Control.Monad                     hiding (forM)
 import           Control.Monad.IO.Class
-import           Data.Attoparsec.ByteString
-import           Data.Attoparsec.ByteString.Char8
-import           Data.Bool
-import qualified Data.ByteString                   as BS
-import           Data.Either.Combinators
 import           Data.Traversable
 
 import           Crypto.Macaroon.Internal

--- a/src/Crypto/Macaroon/Verifier/Internal.hs
+++ b/src/Crypto/Macaroon/Verifier/Internal.hs
@@ -15,20 +15,15 @@ Portability : portable
 -}
 module Crypto.Macaroon.Verifier.Internal where
 
-import           Control.Applicative
 import           Control.Arrow            ((&&&))
-import           Control.Monad
 import           Control.Monad.IO.Class
 import           Crypto.Hash
 import           Data.Bool
 import           Data.Byteable
 import qualified Data.ByteString          as BS
-import           Data.Either
-import           Data.Either.Validation
 import           Data.Foldable
 import           Data.List.NonEmpty       (NonEmpty, nonEmpty)
 import           Data.Maybe
-import           Data.Semigroup
 import           Data.Text                (Text)
 
 import           Crypto.Macaroon.Internal

--- a/src/Crypto/Macaroon/Verifier/Internal.hs
+++ b/src/Crypto/Macaroon/Verifier/Internal.hs
@@ -16,7 +16,6 @@ Portability : portable
 module Crypto.Macaroon.Verifier.Internal where
 
 import           Control.Arrow            ((&&&))
-import           Control.Monad.IO.Class
 import           Crypto.Hash
 import           Data.Bool
 import           Data.Byteable
@@ -59,7 +58,7 @@ verifySig k m = bool (Left SigMismatch) (Right m) $
     derivedKey = toBytes (hmac "macaroons-key-generator" k :: HMAC SHA256)
 
 -- | Given a list of verifiers, verify each caveat of the given macaroon
-verifyCavs :: forall m. (Functor m, MonadIO m)
+verifyCavs :: forall m. (Applicative m)
            => [Caveat -> m VerifierResult]
            -> Macaroon
            -> m (Either ValidationError Macaroon)

--- a/test/Crypto/Macaroon/Instances.hs
+++ b/test/Crypto/Macaroon/Instances.hs
@@ -11,15 +11,9 @@ This test suite is based on the pymacaroons test suite:
 -}
 module Crypto.Macaroon.Instances where
 
-import           Control.Applicative
-import           Control.Monad
-import           Data.Byteable
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as B8
-import           Data.Hex
 import           Data.List
-import           Test.Tasty
-import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
 import           Crypto.Macaroon

--- a/test/Crypto/Macaroon/Serializer/Base64/Tests.hs
+++ b/test/Crypto/Macaroon/Serializer/Base64/Tests.hs
@@ -12,15 +12,14 @@ This test suite is based on the pymacaroons test suite:
 module Crypto.Macaroon.Serializer.Base64.Tests where
 
 
-import qualified Data.ByteString.Char8 as B8
-import Test.Tasty
-import Test.Tasty.HUnit
+import qualified Data.ByteString.Char8     as B8
+import           Test.Tasty
+import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
 import           Crypto.Macaroon
-import           Crypto.Macaroon.Serializer.Base64
 
-import Crypto.Macaroon.Instances
+import           Crypto.Macaroon.Instances
 
 tests :: TestTree
 tests = testGroup "Crypto.Macaroon.Serializer.Base64" [ basic

--- a/test/Crypto/Macaroon/Tests.hs
+++ b/test/Crypto/Macaroon/Tests.hs
@@ -11,14 +11,12 @@ This test suite is based on the pymacaroons test suite:
 -}
 module Crypto.Macaroon.Tests where
 
-import           Data.Byteable
-import qualified Data.ByteString.Char8             as B8
+import qualified Data.ByteString.Char8 as B8
 import           Data.Hex
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Crypto.Macaroon
-import           Crypto.Macaroon.Serializer.Base64
 
 tests :: TestTree
 tests = testGroup "Crypto.Macaroon" [ basic

--- a/test/Crypto/Macaroon/Verifier/Internal/Tests.hs
+++ b/test/Crypto/Macaroon/Verifier/Internal/Tests.hs
@@ -14,9 +14,6 @@ module Crypto.Macaroon.Verifier.Internal.Tests where
 import           Data.Bool
 import qualified Data.ByteString                   as BS
 import qualified Data.ByteString.Char8             as B8
-import           Data.Either
-import           Data.Either.Validation
-import           Data.List
 import           Data.List.NonEmpty                (NonEmpty (..))
 import           Test.Tasty
 import           Test.Tasty.HUnit

--- a/test/Crypto/Macaroon/Verifier/Tests.hs
+++ b/test/Crypto/Macaroon/Verifier/Tests.hs
@@ -12,17 +12,10 @@ This test suite is based on the pymacaroons test suite:
 module Crypto.Macaroon.Verifier.Tests where
 
 
-import qualified Data.ByteString.Char8     as B8
-import           Data.Either
-import           Data.List
+import qualified Data.ByteString.Char8 as B8
 import           Test.Tasty
-import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck
 
 import           Crypto.Macaroon
-import           Crypto.Macaroon.Verifier
-
-import           Crypto.Macaroon.Instances
 
 tests :: TestTree
 tests = testGroup "Crypto.Macaroon.Verifier" [ ]

--- a/test/Sanity.hs
+++ b/test/Sanity.hs
@@ -3,15 +3,12 @@ module Sanity where
 
 import           Crypto.Hash
 import           Data.Byteable
-import           Data.ByteString                         (ByteString)
-import qualified Data.ByteString                         as B
+import           Data.ByteString  (ByteString)
+import qualified Data.ByteString  as B
 import           Data.Hex
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
-
-import qualified Crypto.Macaroon.Serializer.Base64.Tests
-import qualified Crypto.Macaroon.Tests
 
 tests :: TestTree
 tests = testGroup "Python HMAC Sanity check" [ checkKey

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,7 +1,6 @@
 module Main where
 
 import           Test.Tasty
-import           Test.Tasty.HUnit
 
 import qualified Crypto.Macaroon.Serializer.Base64.Tests
 import qualified Crypto.Macaroon.Tests


### PR DESCRIPTION
I gave a shot at improving the verifiers API, as per #11 
I'll try to split up changes in separated commits. There is one commit for imports cleanup, don't pay it too much attention.

# ToDo:
- [x] split up `ValidationError`
- [x] drop the `monadIO` constraint
- [x] investigate the use of a monad transformer for effects and validation -> Later
- [x] investigate letting verifiers access all caveats at the same time (through eg. a zipper) -> Later

First change: split up `ValidationError` into:
- `VerifierResult` (for… well… verifier results).
- `VerifierError` for caveats understood, but not discharged
- `ValidationError` for macaroon validation errors (either an issue with the macaroon itself, or with caveats discharge. Caveat discharge errors are accumulated in a `NonEmpty (Caveat, [VerifierError])` case, which allows to know which caveats failed and why.

This allows to drop the `Monoid ValidationError` previously necessary for error accumulation. It was lossy, and some combinations didn't make sense (to the point that the first `<>` implementation was partial). The caveats validation is now a bit cleaner (even though keeping the caveats around makes it more complex than it could be).

Second change: relax the unused `MonadIO` constraint. This allows to have synchronous verification thanks to `Identity` (I've added a helper to make it even easier).

Third change: introduce a monad transformer to encapsulate both the effects needed for verifier computation and for the verifier results (maybe through a `MonadError` constraint). I'm not convinced it's really necessary, as it would increase complexity a lot, while providing little benefit IMO (macaroon validation errors should be treated right away, not carried on in the context).