### PR TITLE
Small improvements

### DIFF
--- a/src/Crypto/Macaroon/Verifier.hs
+++ b/src/Crypto/Macaroon/Verifier.hs
@@ -47,10 +47,10 @@ verify :: (Applicative m)
        -> m (VerifierResult pe ve)]
        -> Macaroon
        -> m (Either (ValidationError pe ve) Macaroon)
-verify secret verifiers =
+verify secret verifiers m =
     let checkSig = verifySig secret
-        checkCavs = either (pure . Left) (verifyCavs verifiers)
-    in checkCavs . checkSig
+        checkCavs = fmap (fmap $ const m) . either (pure . Left) (verifyCavs verifiers . caveats )
+    in checkCavs . checkSig $ m
 
 -- | Synchronously verify a macaroon signature and caveats, given the
 -- corresponding Secret and verifiers.

--- a/src/Crypto/Macaroon/Verifier.hs
+++ b/src/Crypto/Macaroon/Verifier.hs
@@ -12,6 +12,7 @@ Portability : portable
 -}
 module Crypto.Macaroon.Verifier (
     verify
+  , verifySync
   , VerifierResult(..)
   , VerifierError(..)
   , ValidationError(..)

--- a/test/Crypto/Macaroon/Verifier/Internal/Tests.hs
+++ b/test/Crypto/Macaroon/Verifier/Internal/Tests.hs
@@ -77,22 +77,23 @@ getCids res =
         getCaveats _                     = Nothing
     in errors res
 
+type CavResult = IO (Either ValidationError' ())
 
 firstParty = testGroup "First party caveats" [
     testCase "Zero caveat" $ do
-        res <- verifyCavs [] m :: IO (Either ValidationError' Macaroon)
-        Right m @=? res
+        res <- verifyCavs [] (caveats m) :: CavResult
+        Right () @=? res
     , testCase "One caveat empty" $ do
-        res <- verifyCavs [] m2 :: IO (Either ValidationError' Macaroon)
+        res <- verifyCavs [] (caveats m2) :: CavResult
         Just (("test = caveat",  []) :| [])@=? getCids res
     , testCase "One caveat fail" $ do
-        res <- verifyCavs [vval] m2 :: IO (Either ValidationError' Macaroon)
+        res <- verifyCavs [vval] (caveats m2) :: CavResult
         Just (("test = caveat",  []) :| [])@=? getCids res
     , testCase "One caveat win" $ do
-        res <- verifyCavs [vtest] m2 :: IO (Either ValidationError' Macaroon)
-        Right m2 @=? res
+        res <- verifyCavs [vtest] (caveats m2) :: CavResult
+        Right () @=? res
     , testCase "Two caveat win" $ do
-        res <- verifyCavs [vtest, vval] m3 :: IO (Either ValidationError' Macaroon)
-        Right m3 @=? res
+        res <- verifyCavs [vtest, vval] (caveats m3) :: CavResult
+        Right () @=? res
     ]
 


### PR DESCRIPTION
I've removed the `Monad m` constraint on `verify` (I find the code a little more readable as well, but that's personal, I guess).

I've also make `verifyCavs` work on a list of caveats instead of a macaroon. That allows to reuse the logic to check a list of caveats without a macaroon (eg for 2-step validation).

I've also removed some extensions that were left over (scary stuff like `UndecidableInstances` or `TypeSynonymInstances`)