### PR TITLE
bump(lts): use a more modern LTS

### DIFF
--- a/hmacaroons.cabal
+++ b/hmacaroons.cabal
@@ -70,7 +70,7 @@ library
                   -- nonce,
                   -- cipher-aes >=0.2 && <0.3,
                   deepseq >= 1.1,
-                  hex >= 0.1
+                  hex >= 0.2.0
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -90,7 +90,7 @@ benchmark bench
                   transformers >= 0.3,
                   -- cipher-aes >=0.2 && <0.3,
                   either >=4.4,
-                  hex >= 0.1,
+                  hex >= 0.2.0,
                   deepseq >= 1.1,
                   criterion >= 1.1
 
@@ -107,7 +107,7 @@ test-suite test
                   cereal >= 0.4,
                   cryptohash >=0.11 && <0.12,
                   either >=4.4,
-                  hex >= 0.1,
+                  hex >= 0.2.0,
                   tasty >= 0.10,
                   tasty-hunit >= 0.9,
                   tasty-quickcheck >= 0.8,

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.0
+resolver: lts-16.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -38,7 +38,9 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+  - git: https://github.com/taruti/haskell-hex
+    commit: 5953ae445ae8f608858903280fe3d9d2b503ae31 
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Working on some LTS upgrade on a codebase I maintain, I realise `hmacaroons` is getting hard to use in more modern LTS, as the `hex` package get outdated with the upgrade of the `base` library.

This PR proposes:
- Bumping the reference LTS used by hmacaroons;
- Using the latest available `master` of `hex` which seems to be fit for the task.

Obivously, the ideal scenario would be to have different releases for `hmacaroons` so user do not have to target specific commit but rather a version number to get the hmacaroon release suited to their own environment.